### PR TITLE
Instructor training form wording

### DIFF
--- a/workshops/migrations/0129_trainingrequest_texts_choices.py
+++ b/workshops/migrations/0129_trainingrequest_texts_choices.py
@@ -45,7 +45,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='trainingrequest',
             name='previous_involvement',
-            field=models.ManyToManyField(blank=True, help_text='Please check all that apply.', to='workshops.Role', verbose_name='How often have you been involved with The Carpentries in the following ways'),
+            field=models.ManyToManyField(blank=True, help_text='Please check all that apply.', to='workshops.Role', verbose_name='In which of the following ways have you been involved with The Carpentries'),
         ),
         migrations.AlterField(
             model_name='trainingrequest',

--- a/workshops/models.py
+++ b/workshops/models.py
@@ -2096,8 +2096,7 @@ class TrainingRequest(ActiveMixin, CreatedUpdatedMixin,
 
     previous_involvement = models.ManyToManyField(
         'Role',
-        verbose_name='How often have you been involved with The Carpentries in'
-                     ' the following ways',
+        verbose_name='In which of the following ways have you been involved with The Carpentries',
         help_text='Please check all that apply.',
         blank=True,
     )

--- a/workshops/templates/forms/trainingrequest.html
+++ b/workshops/templates/forms/trainingrequest.html
@@ -12,14 +12,14 @@
 {% block content %}
 
 <p>Our instructor training classes are for people who wish to learn how to
-teach The Carpentries workshops. We teach
-impactful pedagogical techniques and prepare you to become an instructor
+teach Carpentry workshops. We teach
+impactful pedagogical techniques and prepare you to become an Instructor
 in our community. We use this form to register interest and build new
-communities of instructors around the world.</p>
+communities of Instructors around the world.</p>
 
 <p>If you wish to apply to our open instructor training program, please
 fill in the form below. Tell us about yourself, what excites you about
-teaching, how The Carpentries can help in your community.
+teaching, and how The Carpentries can help in your community.
 Spaces are limited, so use this form to share with us what excites you
 about spreading our teaching to your organization. We will notify
 applicants as limited spaces become available. If you have any
@@ -27,7 +27,7 @@ questions, please mail <a href="mailto:training@carpentries.org">
 training@carpentries.org</a>.</p>
 
 <p>If you would like to accelerate the process, check out our
-<a href="http://software-carpentry.org/scf/join/">membership program</a>.
+<a href="http://software-carpentry.org/membership/">membership program</a>.
 Organizational members make ongoing commitments to supporting The Carpentries
 and are guaranteed seats in instructor training. If you need
 help making the case at your organization, feel free to contact us at
@@ -52,7 +52,7 @@ we'd be happy to help.</p>
   within 12 months of the course.</li>
 </ul>
 
-<p>Carpentry instructor training, please see <a href="http://carpentries.github.io/instructor-training/">
+<p>For our instructor training curriculum, please see <a href="http://carpentries.github.io/instructor-training/">
 http://carpentries.github.io/instructor-training/</a>.</p>
 
 <div class="alert alert-info">


### PR DESCRIPTION
Form wording changes

- I've changed "How many times have you been involved . . . " to "In which of the following ways have you been involved". This means we don't need to change the check boxes to pull down boxes with numeric options. 

- I've made some minor wording changes to the form introductory text. 

Your two suggestions about unifying the Code of Conduct and hosting it on the carpentries website and about changing partnerships@ to memberships@ are good ones. The Carpentries website is still in development and the partnership --> membership language change is something that we'll be changing in the future. 

The one last change that I see that needs to be made is: 

- The "I self-identify as a member of a group that is under-represented" question is formatted such that the text intro box is before the question. Could it be formatted like the "I have been an active contributor" question? I think this is just a formatting typo.